### PR TITLE
allow ssh keys to be stored in existing Secret

### DIFF
--- a/charts/athens-proxy/templates/deployment.yaml
+++ b/charts/athens-proxy/templates/deployment.yaml
@@ -226,7 +226,11 @@ spec:
           name: {{ template "fullname" . }}-ssh-git-servers
       - name: ssh-git-servers-secret
         secret:
+          {{- if .Values.sshGitServersKeysExistingSecret }}
+          secretName: {{ .Values.sshGitServersKeysExistingSecret }}
+          {{- else -}}
           secretName: {{ template "fullname" . }}-ssh-git-servers
+          {{- end }}
       {{- end }}
       {{- if .Values.gitconfig.enabled }}
       - name: gitconfig

--- a/charts/athens-proxy/templates/secret-ssh-git-servers.yaml
+++ b/charts/athens-proxy/templates/secret-ssh-git-servers.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.sshGitServers -}}
+{{- if and .Values.sshGitServers (not .Values.sshGitServersKeysExistingSecret) -}}
 kind: Secret
 apiVersion: v1
 metadata:

--- a/charts/athens-proxy/values.yaml
+++ b/charts/athens-proxy/values.yaml
@@ -144,6 +144,11 @@ sshGitServers: {}
     ## ssh port
   #  port: 22
 
+# Store the SSH keys for the sshGitServers above in a pre-existing kubernetes Secret
+# This chart expects each data key in the Secret to be named like:
+#   id_rsa-<sshGitServers.host>
+# sshGitServersKeysExistingSecret: 
+
 goGetWorkers: 3
 
 serviceAccount:


### PR DESCRIPTION
this pr adds a new param `sshGitServersKeysExistingSecret` to the athens helm chart to allow ssh keys to be stored in kubernetes secrets instead of directly passed as a helm param